### PR TITLE
Fix matrix reflection in constant buffers with preceding members; bum…

### DIFF
--- a/Adamantium.Vulkan.Spirv/Adamantium.Vulkan.Spirv.csproj
+++ b/Adamantium.Vulkan.Spirv/Adamantium.Vulkan.Spirv.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <PackageId>Adamantium.Vulkan.Spirv</PackageId>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Authors>Den</Authors>
     <Company>Adamantium studio</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Adamantium.Vulkan.Spirv/Reflection/SpirvReflection.cs
+++ b/Adamantium.Vulkan.Spirv/Reflection/SpirvReflection.cs
@@ -164,11 +164,15 @@ namespace Adamantium.Vulkan.Spirv.Reflection
                         }
                         else
                         {
-                            if (compiler.HasMemberDecoration(shaderResources[i].Base_type_id, offset, Decoration.RowMajor))
+                            // HasMemberDecoration takes the member INDEX (k), not the byte offset. Passing the offset
+                            // only happened to work while a matrix was the first member (offset 0 == index 0); once a
+                            // member precedes it (e.g. a uint64 BDA address), offset != index, the row/col-major lookup
+                            // failed and VariableType defaulted to Scalar -> CopyMatrix was never wired -> NRE on SetValue.
+                            if (compiler.HasMemberDecoration(shaderResources[i].Base_type_id, k, Decoration.RowMajor))
                             {
                                 member.VariableType = ShaderVariableClass.MatrixRows;
                             }
-                            else if (compiler.HasMemberDecoration(shaderResources[i].Base_type_id, offset, Decoration.ColMajor))
+                            else if (compiler.HasMemberDecoration(shaderResources[i].Base_type_id, k, Decoration.ColMajor))
                             {
                                 member.VariableType = ShaderVariableClass.MatrixColumns;
                             }


### PR DESCRIPTION
…p to 1.0.5

SpirvReflection passed the member BYTE OFFSET to HasMemberDecoration where the member INDEX is required. A float4x4 only reflected correctly while it was the first member of a constant buffer (offset 0 == index 0); any preceding member (e.g. a uint64 BDA address) made the RowMajor/ColMajor lookup miss, so the matrix fell back to VariableType=Scalar and consumers never wired up matrix copy -> NRE on SetValue(Matrix4x4F). Pass the member index (k) instead.

Bump package 1.0.4 -> 1.0.5.