### PR TITLE
Regenerate Device.cs (Span-getter copyback) + add CreateShaderFromBinary

### DIFF
--- a/Adamantium.Vulkan/AdamantiumVulkan.Classes.Extensions.cs
+++ b/Adamantium.Vulkan/AdamantiumVulkan.Classes.Extensions.cs
@@ -563,11 +563,82 @@ namespace Adamantium.Vulkan.Core
     {
         public ReadOnlySpan<byte> PCodeBytes
         {
-            set 
+            set
             {
                 if (value.Length % 4 != 0) throw new ArgumentException("SPIR-V size must be % 4");
                 PCode = MemoryMarshal.Cast<byte, uint>(value).ToArray();
                 CodeSize = (nuint)value.Length;
+            }
+        }
+    }
+
+    public unsafe partial class Device
+    {
+        /// <summary>
+        /// Creates a shader object from a driver BINARY (VK_SHADER_CODE_TYPE_BINARY_EXT) with the 16-byte
+        /// <c>pCode</c> alignment the spec mandates (VUID-VkShaderCreateInfoEXT-pCode-08878). The generated struct
+        /// marshaller packs <c>pCode</c> at an 8-byte-aligned cursor offset - fine for SPIR-V (needs 4) but a binary
+        /// needs 16, and NVIDIA rejects an under-aligned binary with <c>VK_INCOMPATIBLE_SHADER_BINARY_EXT</c> even for
+        /// a binary it just produced. This path allocates <c>pCode</c> on a 16-byte boundary so cached binaries load.
+        /// Only the fields the engine sets for shader objects are marshalled (no pNext, no push-constant ranges,
+        /// no specialization info).
+        /// </summary>
+        public Result CreateShaderFromBinary(ShaderCreateInfoEXT info, out ShaderEXT shader)
+        {
+            shader = null;
+            var code = info.PCode.Span;
+            void* alignedCode = NativeMemory.AlignedAlloc((nuint)code.Length, 16);
+            sbyte* namePtr = null;
+            VkDescriptorSetLayout_T* setLayouts = null;
+            try
+            {
+                code.CopyTo(new Span<byte>(alignedCode, code.Length));
+
+                if (!string.IsNullOrEmpty(info.PName))
+                {
+                    var byteCount = System.Text.Encoding.UTF8.GetByteCount(info.PName);
+                    namePtr = (sbyte*)NativeMemory.Alloc((nuint)(byteCount + 1));
+                    var nameSpan = new Span<byte>(namePtr, byteCount + 1);
+                    System.Text.Encoding.UTF8.GetBytes(info.PName, nameSpan);
+                    nameSpan[byteCount] = 0;
+                }
+
+                var setLayoutCount = info.SetLayoutCount;
+                if (setLayoutCount > 0 && !info.PSetLayouts.IsEmpty)
+                {
+                    setLayouts = (VkDescriptorSetLayout_T*)NativeMemory.Alloc((nuint)((int)setLayoutCount * sizeof(VkDescriptorSetLayout_T)));
+                    var src = info.PSetLayouts.Span;
+                    for (int i = 0; i < (int)setLayoutCount; i++) setLayouts[i] = src[i];
+                }
+
+                var native = new VkShaderCreateInfoEXT
+                {
+                    sType = StructureType.ShaderCreateInfoExt,
+                    pNext = null,
+                    flags = info.Flags,
+                    stage = info.Stage,
+                    nextStage = info.NextStage,
+                    codeType = info.CodeType,
+                    codeSize = (nuint)code.Length,
+                    pCode = (byte*)alignedCode,
+                    pName = namePtr,
+                    setLayoutCount = setLayoutCount,
+                    pSetLayouts = setLayouts,
+                    pushConstantRangeCount = 0,
+                    pPushConstantRanges = null,
+                    pSpecializationInfo = null
+                };
+
+                var outShader = stackalloc VkShaderEXT_T[1];
+                var result = Commands.vkCreateShadersEXT(this, 1, &native, null, outShader);
+                if (result == Result.Success) shader = outShader[0];
+                return result;
+            }
+            finally
+            {
+                NativeMemory.AlignedFree(alignedCode);
+                if (namePtr != null) NativeMemory.Free(namePtr);
+                if (setLayouts != null) NativeMemory.Free(setLayouts);
             }
         }
     }

--- a/Adamantium.Vulkan/Core/Generated/Classes/Device.cs
+++ b/Adamantium.Vulkan/Core/Generated/Classes/Device.cs
@@ -6133,7 +6133,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                     pFeedbackInfo = new Adamantium.Vulkan.Core.VideoEncodeSessionParametersFeedbackInfoKHR(*arg2);
                 }
                 pDataSize = (nuint)arg3;
-                pData = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg4, (long)pDataSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg4, (long)pDataSize, pData);
                 return result;
             }
             finally
@@ -7081,7 +7081,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                 var result = Commands.vkGetPipelineBinaryDataKHR(this, arg1, &arg2, &arg3, arg4);
                 pPipelineBinaryKey = new PipelineBinaryKeyKHR(arg2);
                 pPipelineBinaryDataSize = (nuint)arg3;
-                pPipelineBinaryData = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg4, (long)pPipelineBinaryDataSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg4, (long)pPipelineBinaryDataSize, pPipelineBinaryData);
                 return result;
             }
             finally
@@ -7151,7 +7151,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                 var arg3 = stackalloc byte[(int)pDataSize];
                 var result = Commands.vkGetPipelineCacheData(this, arg1, &arg2, arg3);
                 pDataSize = (nuint)arg2;
-                pData = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg3, (long)pDataSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg3, (long)pDataSize, pData);
                 return result;
             }
             finally
@@ -7747,7 +7747,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                 var arg3 = stackalloc byte[(int)pDataSize];
                 var result = Commands.vkGetShaderBinaryDataEXT(this, arg1, &arg2, arg3);
                 pDataSize = (nuint)arg2;
-                pData = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg3, (long)pDataSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg3, (long)pDataSize, pData);
                 return result;
             }
             finally
@@ -7792,7 +7792,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                 var arg5 = stackalloc byte[(int)pInfoSize];
                 var result = Commands.vkGetShaderInfoAMD(this, arg1, shaderStage, infoType, &arg4, arg5);
                 pInfoSize = (nuint)arg4;
-                pInfo = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg5, (long)pInfoSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg5, (long)pInfoSize, pInfo);
                 return result;
             }
             finally
@@ -8071,7 +8071,7 @@ public unsafe partial class Device : IUnmanagedWrapper<Adamantium.Vulkan.Core.In
                 var arg3 = stackalloc byte[(int)pDataSize];
                 var result = Commands.vkGetValidationCacheDataEXT(this, arg1, &arg2, arg3);
                 pDataSize = (nuint)arg2;
-                pData = QuantumBinding.Utils.MarshalContextUtils.UnmarshalBlittableArray(arg3, (long)pDataSize);
+                QuantumBinding.Utils.MarshalContextUtils.CopyNativeToSpan(arg3, (long)pDataSize, pData);
                 return result;
             }
             finally


### PR DESCRIPTION
Pulls in the regenerated GetShaderBinaryDataEXT et al. that copy native data into the caller's Span (was reassigning the by-value param -> all-zero binaries). Adds Device.CreateShaderFromBinary, which creates a shader object from a driver binary with the 16-byte pCode alignment VK_SHADER_CODE_TYPE_BINARY_EXT mandates (VUID-08878) - the generic marshaller only 8-byte-aligns it, which NVIDIA rejects. Together these make the shader-object binary cache actually work.